### PR TITLE
fixed top row of buttons in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.0 - [date]
+## v1.0.0 - 2024-02-07
 
 Initial release of nf-core/readsimulator, created with the [nf-core](https://nf-co.re/) template.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     <img alt="nf-core/readsimulator" src="docs/images/nf-core-readsimulator_logo_light.png">
   </picture>
 </h1>
+
 [![GitHub Actions CI Status](https://github.com/nf-core/readsimulator/workflows/nf-core%20CI/badge.svg)](https://github.com/nf-core/readsimulator/actions?query=workflow%3A%22nf-core+CI%22)
 [![GitHub Actions Linting Status](https://github.com/nf-core/readsimulator/workflows/nf-core%20linting/badge.svg)](https://github.com/nf-core/readsimulator/actions?query=workflow%3A%22nf-core+linting%22)[![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/readsimulator/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.XXXXXXX-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.XXXXXXX)
 
@@ -99,6 +100,7 @@ nf-core/readsimulator was originally written by [Adam Bennett](https://github.co
 
 We thank the following people for their extensive assistance in the development of this pipeline (in alphabetical order):
 
+- [Carson J Miller](https://github.com/CarsonJM)
 - [Lauren Huet](https://github.com/LaurenHuet/)
 - [Philipp Bayer](https://github.com/philippbayer)
 


### PR DESCRIPTION
The top row of buttons weren't displaying properly in the README.md when viewing the repo in a browser. I believe this is because a newline got removed at some point. I've added that newline. I also added Carson to the Credit section. Lastly, I've added a hopeful release date to the changelog